### PR TITLE
Tap `alphagov/homebrew-gds` so that installing `gds-cli` works

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,6 @@
 # 'brew tap'
 tap "homebrew/cask"
+tap "alphagov/gds"
 
 cask "aws-vault"
 cask "dropbox"


### PR DESCRIPTION
- Otherwise this will complain on a new machine that the formula `gds-cli` is unavailable.
- Alternatively, it's installable with `brew "alphagov/gds/gds-cli"`, but this feels cleaner.